### PR TITLE
Optimize `mcts.single_simulation`

### DIFF
--- a/agents/minimax_agent.py
+++ b/agents/minimax_agent.py
@@ -224,7 +224,7 @@ class MinimaxAgent:
 
                     # Create a copy of the game state and apply the action
                     new_state = game_state.copy()
-                    if not new_state.apply_action(action):
+                    if not new_state.apply_action(action, skip_validation=True):
                         continue
 
                     # Evaluate this move with minimax

--- a/examples/mcts_example.py
+++ b/examples/mcts_example.py
@@ -108,7 +108,7 @@ def demonstrate_gameplay():
         print(f"Selected action: {action}")
 
         # Apply action
-        success = azul_state.apply_action(action)
+        success = azul_state.apply_action(action, skip_validation=True)
         if not success:
             print(f"Failed to apply action: {action}")
             break

--- a/game/game_state.py
+++ b/game/game_state.py
@@ -206,9 +206,14 @@ class GameState:
             # Invalid destination
             return False
 
-    def apply_action(self, action: Action) -> bool:
-        """Apply an action and return True if successful."""
-        if not self.is_action_legal(action):
+    def apply_action(self, action: Action, skip_validation: bool = False) -> bool:
+        """Apply an action and return True if successful.
+
+        Args:
+            action: The action to apply
+            skip_validation: If True, skip is_action_legal check (use when action is already validated)
+        """
+        if not skip_validation and not self.is_action_legal(action):
             return False
 
         player = self.players[self.current_player]

--- a/profiling/performance_profiler.py
+++ b/profiling/performance_profiler.py
@@ -359,9 +359,9 @@ def create_profiled_mcts(profiler: AzulProfiler):
             with profiler.time_operation("mcts.action_selection"):
                 return super()._select_action(node)
 
-        def _expand_and_evaluate(self, node):
+        def _expand_and_evaluate(self, node, legal_actions=None):
             with profiler.time_operation("mcts.expand_and_evaluate"):
-                return super()._expand_and_evaluate(node)
+                return super()._expand_and_evaluate(node, legal_actions)
 
         def _backpropagate(self, path, leaf, value):
             with profiler.time_operation("mcts.backpropagate"):

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -461,7 +461,7 @@ def test_azul_game_simulation():
         assert action in legal_actions
 
         # Apply action
-        success = azul_state.apply_action(action)
+        success = azul_state.apply_action(action, skip_validation=True)
         assert success
 
         moves += 1
@@ -493,7 +493,7 @@ def test_full_azul_game_with_mcts():
 
         # Select and apply action
         action = agent.select_action(azul_state)
-        success = azul_state.apply_action(action)
+        success = azul_state.apply_action(action, skip_validation=True)
         assert success
 
         moves += 1

--- a/training/self_play.py
+++ b/training/self_play.py
@@ -132,7 +132,7 @@ class SelfPlayEngine:
                 )
 
             # Apply action
-            success = game_state.apply_action(action)
+            success = game_state.apply_action(action, skip_validation=True)
             if not success:
                 if self.verbose:
                     print(f"Invalid action applied: {action}")


### PR DESCRIPTION
#36 

1. Added `skip_validation=True` parameter to `apply_action()`. MCTS now bypasses redundant `is_action_legal()` checks. All the actions are from `get_legal_actions()` already so check it again is redundant.
2. Eliminated redundant `get_legal_actions` calls: MCTS was calling get_legal_actions() 3 times for the same state. Optimized flow: Call once in search(), pass through to all functions.

Results running `python scripts/profile_self_play.py --simulation 200`

**Before**
```
TIMING BREAKDOWN (sorted by total time):
--------------------------------------------------------------------------------
Operation                      Total(s)   Avg(ms)    Count    Calls/s   
--------------------------------------------------------------------------------
total_self_play                147.915    147915.04  1        0.0       
self_play.full_game            147.915    147914.99  1        0.0       
mcts.full_search               147.449    862.27     171      1.2       
mcts.single_simulation         146.752    4.29       34200    233.0     
mcts.expand_and_evaluate       143.174    4.34       33018    230.6     
game.copy                      66.493     0.10       684911   10300.4   
game.apply_action              30.883     0.04       687633   22266.1   
nn.forward_pass                21.219     4.00       5304     250.0     
nn.inference                   17.551     3.31       5304     302.2     
game.is_action_legal           11.452     0.02       687633   60046.1   
game.get_legal_actions         8.805      0.23       38150    4333.0    
nn.state_conversion            3.544      0.67       5304     1496.5    
mcts.action_selection          2.033      0.02       110890   54556.4   
mcts.backpropagate             0.206      0.01       34200    165654.1
```

**After**
```
TIMING BREAKDOWN (sorted by total time):
--------------------------------------------------------------------------------
Operation                      Total(s)   Avg(ms)    Count    Calls/s   
--------------------------------------------------------------------------------
total_self_play                41.405     41405.40   1        0.0       
self_play.full_game            41.405     41405.36   1        0.0       
mcts.full_search               40.864     204.32     200      4.9       
mcts.expand_and_evaluate       39.599     0.99       40200    1015.2    
mcts.single_simulation         39.585     0.99       40000    1010.5    
nn.forward_pass                0.793      3.97       200      252.1     
nn.inference                   0.649      3.25       200      308.1     
mcts.backpropagate             0.180      0.00       40000    222004.3  
nn.state_conversion            0.140      0.70       200      1433.2 
```

While there are some randomness in each game play, we can clearly see the benefit: a single game simulation is now way faster (4.29ms to 0.99ms!)